### PR TITLE
Minor edits to punctuation

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -42,13 +42,13 @@ title: hello
       <div class="justify-content-center row">
         <div class="col-10">
           <div class="section-title">
-            <h2>Batfish supports a wide-variety of analyses</h2>
+            <h2>Batfish supports a wide variety of analyses</h2>
           </div>
 
           <div class="row">
               <div class="card bg-none border-0 col-lg-6">
                 <div class="card-body">
-                  <h5 class="card-title">1. Compliance and best-practices guidelines, e.g.:</h5>
+                  <h5 class="card-title">1. Compliance and best-practices guidelines</h5>
                   <div class="card-text">
                     <ul>
                       <li class="py-2">Flag undefined-but-referenced or defined-but-unreferenced structures (e.g., ACLs, route maps)</li>
@@ -59,7 +59,7 @@ title: hello
               </div>
               <div class="card bg-none border-0 col-lg-6">
                 <div class="card-body">
-                  <h5 class="card-title">2. Checks on data flow, e.g.:</h5>
+                  <h5 class="card-title">2. Checks on data flow</h5>
                   <div class="card-text">
                     <ul>
                       <li class="py-2">Path (shape) between two devices is as expected (e.g., traverses a firewall, valley-free routing)</li>
@@ -73,10 +73,10 @@ title: hello
           <div class="row">
               <div class="card bg-none border-0 col-lg-6">
                 <div class="card-body">
-                  <h5 class="card-title">3. Fault-tolerance, e.g.:</h5>
+                  <h5 class="card-title">3. Fault tolerance</h5>
                   <div class="card-text">
                     <ul>
-                      <li class="py-2">End-to-end reachability is not impacted for any flow after any single-link or -device failure</li>
+                      <li class="py-2">End-to-end reachability is not impacted for any flow after any single-link or single-device failure</li>
                       <li class="py-2">Traffic correctly fails over after a failure</li>
                     </ul>
                   </div>
@@ -84,7 +84,7 @@ title: hello
               </div>
               <div class="card bg-none border-0 col-lg-6">
                 <div class="card-body">
-                  <h5 class="card-title">4. "Differential" analysis of two sets of configuration, e.g.:</h5>
+                  <h5 class="card-title">4. Differential analysis of two sets of configurations</h5>
                   <div class="card-text">
                     <ul>
                       <li class="py-2">End-to-end reachability is identical across new and old configurations</li>
@@ -108,14 +108,14 @@ title: hello
 
           <div class="content-row my-4">
             <a href="https://youtu.be/sKApcGY6MxQ">
-              <h4>NANONG 65 : Proactive Network Configuration Validation with Batfish</h4>
+              <h4>NANOG 65 : Proactive Network Configuration Validation with Batfish</h4>
             </a>
             <p>Ari Fogel, Ratul Mahajan, Todd Millstein</p>
           </div>
 
           <div class="content-row my-4">
             <a href="https://youtu.be/BoLjaiP2Dio">
-              <h4>NANONG 70 : Minesweeper and Propane: Two Tools for Improving Network Reliability</h4>
+              <h4>NANOG 70 : Minesweeper and Propane: Two Tools for Improving Network Reliability</h4>
             </a>
             <p>Ryan Beckett</p>
           </div>
@@ -132,7 +132,7 @@ title: hello
           </div>
           <div class="content-row my-4">
             <a href="https://www.usenix.org/system/files/conference/osdi16/osdi16-fayaz.pdf">
-              <h4>Efficient Network Reachability Analysis using a Succinct Control Plane Representation</h4>
+              <h4>Efficient Network Reachability Analysis Using a Succinct Control Plane Representation</h4>
             </a>
             <p>Seyed K. Fayaz, Tushar Sharma, Ari Fogel, Ratul Mahajan, Todd Millstein, Vyas Sekar, George Varghese</p>
             <p>USENIX Symposium on Operating Systems Design and Implementation (OSDI) 2016</p>


### PR DESCRIPTION
List of changes, in case it's hard to spot them in the diff:
- `wide-variety` -> `wide variety`
- took off the `e.g.:` at the end of the types of analyses (this one's subjective, I can go back on it if people are attached to the current version)
- `fault-tolerance` -> `fault tolerance`
- `single-link or -device failure` -> `single-link or single-device failure`, because I was seeing a new line between `-` and `device`, which looked weird
- `"Differential" analysis of two sets of configuration`: Took out quotes and pluralized `configuration`
- `NANONG` -> `NANOG`
- Capitalized "Using" in `Efficient Network Reachability Analysis Using a Succinct Control Plane Representation`