### PR TITLE
Update google tag manager setup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ title: Batfish
 description: >- # this means to ignore newlines until "baseurl:"
 url: "https://batfish.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
+google_analytics: GTM-TZKVKVG
 intentionet_url: https://www.intentionet.com/
 
 # Social

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,6 @@ title: Batfish
 description: >- # this means to ignore newlines until "baseurl:"
 url: "https://batfish.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
-google_analytics: UA-119529932-1
 intentionet_url: https://www.intentionet.com/
 
 # Social

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,12 +1,3 @@
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-100596389-3"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag() { dataLayer.push(arguments); }
-  gtag('js', new Date());
-
-  gtag('config', 'UA-100596389-3');
-</script>
 <div class="container-fluid bg-gradient-1">
   <div class="container text-center p-2">
     <p class="m-0 lead">

--- a/_includes/google-analytics-noscript.html
+++ b/_includes/google-analytics-noscript.html
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TZKVKVG"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/_includes/google-analytics-noscript.html
+++ b/_includes/google-analytics-noscript.html
@@ -1,4 +1,4 @@
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TZKVKVG"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google_analytics }}"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -3,5 +3,5 @@
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-TZKVKVG');</script>
+})(window,document,'script','dataLayer','{{ site.google_analytics }}');</script>
 <!-- End Google Tag Manager -->

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,13 +1,7 @@
-<script>
-  if (!(window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1")) {
-    (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date(); a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-
-    ga('create', '{{ site.google_analytics }}', 'auto');
-    ga('send', 'pageview');
-  }
-</script>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TZKVKVG');</script>
+<!-- End Google Tag Manager -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
 
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   {%- feed_meta -%}
-  {%- if jekyll.environment == 'production' and site.google_analytics -%}
+  {%- if jekyll.environment == 'production' -%}
   {%- include google-analytics.html -%}
   {%- endif -%}
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
 
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   {%- feed_meta -%}
-  {%- if jekyll.environment == 'production' -%}
+  {%- if jekyll.environment == 'production' and site.google_analytics -%}
   {%- include google-analytics.html -%}
   {%- endif -%}
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   {%- include head.html -%}
 
   <body class="bg-gradient">
-    {%- if jekyll.environment == 'production' -%}
+    {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics-noscript.html -%}
     {%- endif -%}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,10 @@
   {%- include head.html -%}
 
   <body class="bg-gradient">
+    {%- if jekyll.environment == 'production' -%}
+    {%- include google-analytics-noscript.html -%}
+    {%- endif -%}
+
     {%- include intentionet-banner.html -%}
     <main class="page-content" aria-label="Content">
       <div class="wrapper">


### PR DESCRIPTION
Replaces #78 

- Removed GA script from `banner.html`
- Replaced content in `google-analytics.html` with the snippet provided by gtag
- Added `google-analytics-noscript.html` for the noscript snippet provided by gtag
- Removed `google_analytics` config since we no longer use it in templates, and we prefer copy-n-pasting original snippets over templating